### PR TITLE
FIX: 포스트의 말풍선 아이콘 & 썸네일 클릭시 모달 팝업 오픈

### DIFF
--- a/src/components/post/Post.vue
+++ b/src/components/post/Post.vue
@@ -11,7 +11,7 @@
         </div> 
     </div>
     <!-- photo -->
-    <div class="w-full">
+    <div class="w-full cursor-pointer" @click="toggleDialog(index)">
         <img class="w-full" :src="filename">
     </div>
     <div class="px-3 pt-3 pb-1">
@@ -24,11 +24,11 @@
                 <div @click="likesUP()" v-else>
                     <svg aria-label="좋아요 취소" color="#ed4956" fill="#ed4956" height="24" role="img" viewBox="0 0 48 48" width="24"><path d="M34.6 3.1c-4.5 0-7.9 1.8-10.6 5.6-2.7-3.7-6.1-5.5-10.6-5.5C6 3.1 0 9.6 0 17.6c0 7.3 5.4 12 10.6 16.5.6.5 1.3 1.1 1.9 1.7l2.3 2c4.4 3.9 6.6 5.9 7.6 6.5.5.3 1.1.5 1.6.5s1.1-.2 1.6-.5c1-.6 2.8-2.2 7.8-6.8l2-1.8c.7-.6 1.3-1.2 2-1.7C42.7 29.6 48 25 48 17.6c0-8-6-14.5-13.4-14.5z"></path></svg>   
                 </div>
-                <svg @click="setFocus(index)" class="hover:opacity-60 cursor-pointer" color="#262626" fill="#262626" height="24" role="img" viewBox="0 0 24 24" width="24"><path d="M20.656 17.008a9.993 9.993 0 10-3.59 3.615L22 22z" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="2"></path></svg>
+                <svg @click="toggleDialog(index)" class="hover:opacity-60 cursor-pointer" color="#262626" fill="#262626" height="24" role="img" viewBox="0 0 24 24" width="24"><path d="M20.656 17.008a9.993 9.993 0 10-3.59 3.615L22 22z" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="2"></path></svg>
             </div>
-            <div class="cursor-pointer">
+            <!-- <div class="cursor-pointer">
                 <svg class="hover:opacity-60" color="#262626" fill="#262626" height="24" role="img" viewBox="0 0 24 24" width="24"><polygon fill="none" points="20 21 12 13.44 4 21 4 3 20 3 20 21" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></polygon></svg>
-            </div>
+            </div> -->
         </div>
         <!-- info : like -->
         <p class="text-sm font-semibold pt-3 pb-2">좋아요 {{ likeCnt }}개</p>
@@ -43,7 +43,6 @@
     </div>
     <!-- comment : list -->
     <div class="px-3">
-
         <button v-if="commentCnt" @click="toggleDialog(index)" class="text-gray-500 text-sm">댓글 {{ commentCnt }}개 보기</button>
     </div>
     <!-- info : created date -->
@@ -127,9 +126,9 @@
                                 <!-- <svg @click="likesUP()" class="hover:opacity-60 cursor-pointer" color="#262626" fill="#262626" height="24" role="img" viewBox="0 0 24 24" width="24"><path d="M16.792 3.904A4.989 4.989 0 0121.5 9.122c0 3.072-2.652 4.959-5.197 7.222-2.512 2.243-3.865 3.469-4.303 3.752-.477-.309-2.143-1.823-4.303-3.752C5.141 14.072 2.5 12.167 2.5 9.122a4.989 4.989 0 014.708-5.218 4.21 4.21 0 013.675 1.941c.84 1.175.98 1.763 1.12 1.763s.278-.588 1.11-1.766a4.17 4.17 0 013.679-1.938m0-2a6.04 6.04 0 00-4.797 2.127 6.052 6.052 0 00-4.787-2.127A6.985 6.985 0 00.5 9.122c0 3.61 2.55 5.827 5.015 7.97.283.246.569.494.853.747l1.027.918a44.998 44.998 0 003.518 3.018 2 2 0 002.174 0 45.263 45.263 0 003.626-3.115l.922-.824c.293-.26.59-.519.885-.774 2.334-2.025 4.98-4.32 4.98-7.94a6.985 6.985 0 00-6.708-7.218z"></path></svg> -->
                                 <svg @click="setFocus()" class="hover:opacity-60 cursor-pointer" color="#262626" fill="#262626" height="24" role="img" viewBox="0 0 24 24" width="24"><path d="M20.656 17.008a9.993 9.993 0 10-3.59 3.615L22 22z" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="2"></path></svg>
                             </div>
-                            <div class="cursor-pointer">
+                            <!-- <div class="cursor-pointer">
                                 <svg class="hover:opacity-60" color="#262626" fill="#262626" height="24" role="img" viewBox="0 0 24 24" width="24"><polygon fill="none" points="20 21 12 13.44 4 21 4 3 20 3 20 21" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></polygon></svg>
-                            </div>
+                            </div> -->
                         </div>
                         <!-- info : like -->
                         <p class="text-sm font-semibold pt-3 pb-2">좋아요 {{ likeCnt }}개</p>


### PR DESCRIPTION
- 포스트 말풍선 아이콘 클릭시 모달 팝업 오픈
- 썸네일 클릭시 모달 팝업 오픈
- 보관 아이콘 삭제 처리